### PR TITLE
Log output to STDOUT, instead of STDERR

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -31,7 +31,7 @@ if sys.version_info[0] == 2:
         urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.StreamHandler())
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 if os.environ.get('CF_DEBUG'):
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
By default, Python logs the output to STDERR (https://docs.python.org/3/howto/logging.html#what-happens-if-no-configuration-is-provided) - this change makes the output from the hook go to STDOUT, as errors should probably be raised by Dehydrated itself rather than the hook.