### PR TITLE
Replace Email/Key with API token for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ $ pip3 install -r hooks/cloudflare/requirements.txt
 
 ### Configuration
 
-Your account's CloudFlare email and API key are expected to be in the environment, so make sure to:
+An API token from your CloudFlare account is expected to be in the environment, so make sure to:
 
 ```
-$ export CF_EMAIL='user@example.com'
-$ export CF_KEY='K9uX2HyUjeWg5AhAb'
+$ export CF_API_TOKEN='ABLQcziApPVRAEjXpa9bzXcHySpzja24zcTOzkV7'
 ```
 
-You can supply multiple account credentials by separating them with one or more spaces.  Accounts will be tried in the order given, until one is found that serves the relevant domain.
-Leading, trailing, and extra spaces are ignored, so you can vertically align credential pairs for easy reading:
+API tokens need the `Zone.Zone` and `Zone.DNS` permissions. You can restrict them by source IP and for specific zones.
+
+You can supply multiple API tokens credentials by separating them with one or more spaces.  Tokens will be tried in the order given, until one is found that serves the relevant domain.
+Leading, trailing, and extra spaces are ignored.
 
 ```
-$ export CF_EMAIL='user1@example.com    user2@somewhere.com'
-$ export CF_KEY='  K9uX2HyUjeWg5AhAtreb fdsfjhFdaKls45354kHJ9hsj'
+$ export CF_API_TOKEN='ABLQcziApPVRAEjXpa9bzXcHySpzja24zcTOzkV7 GingohChi0eithaigaushiuHudaef3ag6eef1cah'
 ```
 
 Optionally, you can specify the DNS servers to be used for propagation checking via the `CF_DNS_SERVERS` environment variable (props [bennettp123](https://github.com/bennettp123)):
@@ -64,8 +64,7 @@ $ export CF_DEBUG='true'
 Alternatively, these statements can be placed in `dehydrated/config`, which is automatically sourced by `dehydrated` on startup:
 
 ```
-echo "export CF_EMAIL=user@example.com" >> config
-echo "export CF_KEY=K9uX2HyUjeWg5AhAb" >> config
+echo "export CF_API_TOKEN=ABLQcziApPVRAEjXpa9bzXcHySpzja24zcTOzkV7" >> config
 echo "export CF_DEBUG=true" >> config
 ```
 
@@ -123,13 +122,12 @@ $ (dehydrated_env) pip3 install -r hooks/cloudflare/requirements.txt
 ```
 
 ### Usage with a bash script
-You can take a shortcut by creating a bash script (such as `domaincert.sh` in `~/cert_workspace`) as following to generate your certificate quickly since you need to regenerate your certificates once every 90 days. Replace CF_EMAIL (your Cloudflare email), CF_KEY (your Cloudflare API Key), and DOMAIN variables with your own info. The following assumes that the bash script is stored where you created the git clone folder for dehydrated to reduce the chances of accidentally checking in the bash script into a git repo because it is a good security practice not to store credentials in git repos.
+You can take a shortcut by creating a bash script (such as `domaincert.sh` in `~/cert_workspace`) as following to generate your certificate quickly since you need to regenerate your certificates once every 90 days. Replace `CF_API_TOKEN` (your Cloudflare API token), and `DOMAIN` variables with your own info. The following assumes that the bash script is stored where you created the git clone folder for dehydrated to reduce the chances of accidentally checking in the bash script into a git repo because it is a good security practice not to store credentials in git repos.
 
 ```
 #!/bin/bash
 
-export CF_EMAIL='user@example.com'
-export CF_KEY='K9uX2HyUjeWg5AhAb'
+export CF_API_TOKEN='ABLQcziApPVRAEjXpa9bzXcHySpzja24zcTOzkV7'
 export DOMAIN='my.domain.com'
 
 export CF_DNS_SERVERS='8.8.8.8 8.8.4.4'

--- a/hook.py
+++ b/hook.py
@@ -20,12 +20,11 @@ else:
 
 try:
     CF_HEADERS = [{
-        'X-Auth-Email': e,
-        'X-Auth-Key'  : k,
+        'Authorization': f'Bearer {b}'
         'Content-Type': 'application/json',
-    } for e,k in zip(os.environ['CF_EMAIL'].split(), os.environ['CF_KEY'].split()) ]
+    } for b in os.environ['CF_API_TOKEN'].split() ]
 except KeyError:
-    logger.error(" + Unable to locate Cloudflare credentials in environment!")
+    logger.error(" + Unable to locate Cloudflare API token (CF_API_TOKEN) in environment!")
     sys.exit(1)
 
 try:

--- a/tests/unit/test__hook.py
+++ b/tests/unit/test__hook.py
@@ -14,8 +14,7 @@ from six.moves.urllib import parse as urlparse
 import testtools
 
 # Setup dummy environment variables so 'hook' can be imported
-os.environ['CF_EMAIL'] = "email@example'com"
-os.environ['CF_KEY'] = "a_cloudflare_example_key"
+os.environ['CF_API_TOKEN'] = "a_cloudflare_api_token"
 
 import hook  # noqa
 
@@ -31,8 +30,7 @@ class TestBase(testtools.TestCase):
         super(TestBase, self).setUp()
         self.expected_headers = {
             'Content-Type': 'application/json',
-            'X-Auth-Email': "email@example'com",
-            'X-Auth-Key': 'a_cloudflare_example_key',
+            'Authorization': 'Bearer a_cloudflare_api_token',
         }
 
 


### PR DESCRIPTION
Cloudflare offers fine-grained API tokens, which really should be the preferred method to authenticate against their API; hereby proposing to replace the CF_EMAIL/CF_KEY with CF_API_TOKEN everywhere.

(Yes, having backwards' compatibility would be nice, but more work (especially in the documentation side).